### PR TITLE
Disable numpad arrow keys

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -376,37 +376,3 @@ var request = function(method, url, body, resolve, reject) {
   xhr.send(body);
 };
 
-
-function handleKey(e) {
-  console.log(e.keyCode);
-  switch (e.keyCode) {
-    case 50:
-    case 98:
-      Mousetrap.trigger('down');
-      return false;
-    case 52:
-    case 55:
-    case 100:
-    case 121:
-    case 122:
-      Mousetrap.trigger('left');
-      return false;
-    case 54:
-    case 102:
-      Mousetrap.trigger('right');
-      return false;
-    case 56:
-    case 104:
-      Mousetrap.trigger('up');
-      return false;
-    case 45:
-      Mousetrap.trigger('minus');
-      return false;
-    case 43:
-      Mousetrap.trigger('plus');
-      return false;
-    default:
-  }
-}
-document.body.addEventListener('keypress', handleKey);
-


### PR DESCRIPTION
This was a hack I added to make the numpad arrow keys work. (It also tried to make `-`/`+` work better, but in fact Mousetrap seems to handle those ok by itself.)

I think we should remove it, because:
- it may be buggy
- the arrow keys are potentially easier to use
