### PR TITLE
Add numpad key support, again

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -341,3 +341,22 @@ var request = function(method, url, body, resolve, reject) {
 	xhr.send(body);
 };
 
+
+// hack numpad key support into mousetrap
+
+var numpadKeys = {
+  98: 'down',
+  100: 'left',
+  102: 'right',
+  104: 'up',
+};
+
+document.body.addEventListener('keypress', function(e) {
+  var name = numpadKeys[e.keyCode];
+  if (name) {
+	Mousetrap.trigger(name);
+	e.preventDefault();
+	return false;
+  }
+});
+


### PR DESCRIPTION
Fixes #54

This makes the keys `2`, `4`, `6`, `8` on the num pad function as arrow keys `↓`, `←`, `→`, `↑`.
