### PR TITLE
Empty loops; can add to start of a loop

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -171,7 +171,7 @@ Mousetrap.bind(['plus', '+'], function() {
 
 //shortcut to delete a node
 Mousetrap.bind(['minus', '-'], function() {
-	if (activeNode.name == "tempo" || (activeNode.parent.children.length == 1 && activeNode.name != 'effect' && activeNode.parent.name.substring(0, 4) != 'loop') || activeNode.name == 'effect name' || activeNode.parent instanceof PlayNode || (activeNode instanceof FXNode && activeNode.parent.children.length == 1 && activeNode.children.length == 1)) {
+	if (activeNode.name == "tempo" || (activeNode.parent.children.length == 1 && activeNode.name != 'effect' && activeNode.parent.name.substring(0, 4) != 'loop') || activeNode.name == 'effect name' || activeNode.parent instanceof PlayNode) {
 		say('You cannot delete this code. ' + activeNode.readName() + ' is currently selected');
 		mode = null;
 	} else {

--- a/js/main.js
+++ b/js/main.js
@@ -323,19 +323,18 @@ Mousetrap.bind(['right', 'd', 'l'], function() {
 						activeNode = new SleepNode(newNodeParent, newNodeIndex);
 						break;
 					case 2: // fx
-						// This shouldn't behave any differently depending on the value of selectedCodePosition.
 						response += "New FX added around " ;
-						for (var i = 0; i < activeNode.parent.children.length; i++){
-							response += activeNode.parent.children[i].readName();
-							if ( i == (activeNode.parent.children.length - 2))
+						for (var i = 0; i < newNodeParent.children.length; i++){
+							response += newNodeParent.children[i].readName();
+							if ( i == (newNodeParent.children.length - 2))
 								response += " and ";
-							else if ( i == (activeNode.parent.children.length - 1))
+							else if ( i == (newNodeParent.children.length - 1))
 								response += ". ";
 							else 
 								response += ", ";
 						}
 						
-						activeNode = new FXNode(activeNode.parent);
+						activeNode = new FXNode(newNodeParent);
 						break;
 					case 3: // synth
 						response += "New synth added " + newNodeMsg + activeNode.readName() + '. ';
@@ -364,19 +363,18 @@ Mousetrap.bind(['right', 'd', 'l'], function() {
 						activeNode = new SleepNode(newNodeParent, newNodeIndex);
 						break;
 					case 3: // fx
-						// This shouldn't behave any differently depending on the value of selectedCodePosition.
 						response += "New FX added around " ;
-						for (var i = 0; i < activeNode.parent.children.length; i++){
-							response += activeNode.parent.children[i].readName();
-							if ( i == (activeNode.parent.children.length - 2))
+						for (var i = 0; i < newNodeParent.children.length; i++){
+							response += newNodeParent.children[i].readName();
+							if ( i == (newNodeParent.children.length - 2))
 								response += " and ";
-							else if ( i == (activeNode.parent.children.length - 1))
+							else if ( i == (newNodeParent.children.length - 1))
 								response += ". ";
 							else 
 								response += ", ";
 						}
 						
-						activeNode = new FXNode(activeNode.parent);
+						activeNode = new FXNode(newNodeParent);
 						break;
 					case 4: // synth
 						response += "New synth added " + newNodeMsg + activeNode.readName() + '. ';
@@ -445,8 +443,10 @@ Mousetrap.bind(['right', 'd', 'l'], function() {
 		case 'add-loop': // choose where to add code relative to a loop
 			selectedCodeType = 0;
 			if (selectedCodePosition == 1 && activeNode.name.substr(0, 4) == 'loop') {
+				inLoop = true;
 				codeTypes = [ "play", "sleep", "fx", "synth", "sample" ];
 			} else {
+				inLoop = false;
 				codeTypes = [ "loop", "play", "sleep", "synth", "sample" ];
 			}
 			say("What do you want to add? " + codeTypes[selectedCodeType] + "; " + (selectedCodeType + 1) + " of " + codeTypes.length);

--- a/js/main.js
+++ b/js/main.js
@@ -185,7 +185,7 @@ Mousetrap.bind(['plus', '+'], function() {
 
 //shortcut to delete a node
 Mousetrap.bind(['minus', '-'], function() {
-	if (activeNode.name == "tempo" || (activeNode.parent.children.length == 1 && activeNode.name != 'fx' && activeNode.parent.name.substring(0, 4) != 'loop') || activeNode instanceof ChoiceNode || activeNode.parent instanceof PlayNode) {
+	if (activeNode.name == "tempo" || (activeNode.parent.children.length == 1 && activeNode.name != 'fx' && activeNode.parent.name.substr(0, 4) != 'loop') || activeNode instanceof ChoiceNode || activeNode.parent instanceof PlayNode) {
 		say('You cannot delete this code. ' + activeNode.readName() + ' is currently selected');
 		mode = null;
 	} else {
@@ -329,7 +329,7 @@ Mousetrap.bind(['right', 'd', 'l'], function() {
 			var newNodeMsg = selectedCodePosition == 1 ? "at the start of " : "after ";
 			var newNodeParent = selectedCodePosition == 1 ? activeNode : activeNode.parent;
 			var newNodeIndex = selectedCodePosition == 1 ? 0 : (activeNode.parent.children.indexOf(activeNode) + 1);
-			if (activeNode.parent.name.substr(0, 4) == 'loop') {
+			if (activeNode.parent.name.substr(0, 4) == 'loop' || (selectedCodePosition == 1 && activeNode.name.substr(0, 4) == 'loop')) {
 				switch (selectedCodeType) {
 					case 0: // play
 						response += "New note added " + newNodeMsg + activeNode.readName() + '. ';
@@ -460,6 +460,7 @@ Mousetrap.bind(['right', 'd', 'l'], function() {
 			break;
 		case 'add-loop': // choose where to add code relative to a loop
 			selectedCodeType = 0;
+			if (selectedCodePosition == 1 && activeNode.name.substr(0, 4) == 'loop') codeTypes = [ "play", "sleep", "fx", "synth", "sample" ];
 			say("What do you want to add? " + codeTypes[selectedCodeType] + "; " + (selectedCodeType + 1) + " of " + codeTypes.length);
 			mode = 'add';
 			break;

--- a/js/main.js
+++ b/js/main.js
@@ -417,6 +417,7 @@ Mousetrap.bind(['right', 'd', 'l'], function() {
 			}
 			actionIndex++;
 			say(response + activeNode.readFull());
+			selectedCodePosition = 0;
 			mode = null;
 			break;
 		case 'bind-cubelet': // select cubelet

--- a/js/main.js
+++ b/js/main.js
@@ -171,7 +171,7 @@ Mousetrap.bind(['plus', '+'], function() {
 
 //shortcut to delete a node
 Mousetrap.bind(['minus', '-'], function() {
-	if (activeNode.name == "tempo" || (activeNode.parent.children.length == 1 && activeNode.name != 'effect') || activeNode.name == 'effect name' || activeNode.parent instanceof PlayNode || (activeNode instanceof FXNode && activeNode.parent.children.length == 1 && activeNode.children.length == 1)) {
+	if (activeNode.name == "tempo" || (activeNode.parent.children.length == 1 && activeNode.name != 'effect' && activeNode.parent.name.substring(0, 4) != 'loop') || activeNode.name == 'effect name' || activeNode.parent instanceof PlayNode || (activeNode instanceof FXNode && activeNode.parent.children.length == 1 && activeNode.children.length == 1)) {
 		say('You cannot delete this code. ' + activeNode.readName() + ' is currently selected');
 		mode = null;
 	} else {
@@ -200,8 +200,10 @@ Mousetrap.bind(['minus', '-'], function() {
 				activeNode.parent.children.splice(index, 1);
 				if (index > 0) {
 					activeNode = activeNode.parent.children[index - 1];
-				} else {
+				} else if (activeNode.parent.children.length > 0) {
 					activeNode = activeNode.parent.children[index];
+				} else {
+					activeNode = activeNode.parent;
 				}
 			}
 			say("Code deleted. Press control+Z to undo. The currently selected bit of code is " + activeNode.readFull());

--- a/js/main.js
+++ b/js/main.js
@@ -131,6 +131,9 @@ Mousetrap.bind(['c'], function() {
 
 //shortcut to add a node
 Mousetrap.bind(['plus', '+'], function() {
+	// These two variables should always begin at their default values when this keyboard shortcut is used.
+	inLoop = false;
+	selectedCodePosition = 0;
 	if (['root', 'fx'].indexOf(activeNode.parent.name) < 0 && activeNode.parent.name.substr(0, 4) != 'loop') {
 		say('You cannot add code here. ' + activeNode.readName() + ' is currently selected');
 		mode = null;
@@ -273,6 +276,8 @@ Mousetrap.bind(['command+y', 'ctrl+y'], function() {
 Mousetrap.bind(['left', 'a', 'h'], function() {
 	switch (mode) {
 		case 'add': // add code
+			inLoop = false;
+			selectedCodePosition = 0;
 			mode = null;
 			say("Adding code cancelled. The currently selected bit of code is " + activeNode.readFull());
 			break;
@@ -398,6 +403,7 @@ Mousetrap.bind(['right', 'd', 'l'], function() {
 			}
 			actionIndex++;
 			say(response + activeNode.readFull());
+			inLoop = false;
 			selectedCodePosition = 0;
 			mode = null;
 			break;


### PR DESCRIPTION
Fixes #76. You can now delete all child nodes of a loop and have the
option of adding a new node to the start of a loop as an alternative to
adding nodes after the loop, if a loop is currently selected.
