### PR TITLE
Fix numpad key support

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -676,7 +676,7 @@ var numpadKeys = {
   104: 'up',
 };
 
-document.body.addEventListener('keypress', function(e) {
+document.body.addEventListener('keydown', function(e) {
   var name = numpadKeys[e.keyCode];
   if (name) {
 	Mousetrap.trigger(name);


### PR DESCRIPTION
Turns out `keypress` uses different keycodes to `keydown`...
